### PR TITLE
Add initial empty row when open modal profile contact details

### DIFF
--- a/vue-app/src/components/profiles/ProfileCommunicationsForm.vue
+++ b/vue-app/src/components/profiles/ProfileCommunicationsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {nextTick, onBeforeMount, onMounted, ref, watch} from 'vue'
+import { nextTick, onBeforeMount, onMounted, ref, watch } from 'vue'
 import { ProfileCommunicationService } from '@/services/profiles/ProfileCommunicationService'
 import ProfileCommunicationForm from './ProfileCommunicationForm.vue'
 import { IdentityHelper } from '@/helpers/IdentityHelper'
@@ -39,7 +39,9 @@ onBeforeMount(() => {
 
 onMounted(async () => {
   await nextTick()
-  addProfileCommunication()
+  if (profile.value.communications.length === 0) {
+    addProfileCommunication()
+  }
 })
 
 const saveProfileCommunications = () => {

--- a/vue-app/src/components/profiles/ProfileCommunicationsForm.vue
+++ b/vue-app/src/components/profiles/ProfileCommunicationsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, ref, watch } from 'vue'
+import {nextTick, onBeforeMount, onMounted, ref, watch} from 'vue'
 import { ProfileCommunicationService } from '@/services/profiles/ProfileCommunicationService'
 import ProfileCommunicationForm from './ProfileCommunicationForm.vue'
 import { IdentityHelper } from '@/helpers/IdentityHelper'
@@ -35,6 +35,11 @@ const profileCommunicationService = new ProfileCommunicationService(axios)
 
 onBeforeMount(() => {
   reloadProfileCommunications()
+})
+
+onMounted(async () => {
+  await nextTick()
+  addProfileCommunication()
 })
 
 const saveProfileCommunications = () => {


### PR DESCRIPTION
**Before Change**
1. click "+ADD" button in profile
![image](https://github.com/mate-n/tpms/assets/3841068/6dd288e6-6d50-40a6-83b4-9d82ebe4a894)

2. click edit button in contact details
![image](https://github.com/mate-n/tpms/assets/3841068/d7f94339-01c5-4a15-ac8f-346d834eba8f)

3. When opening the contact details inside the profile details view, it is empty totally
![image](https://github.com/mate-n/tpms/assets/3841068/262fd220-9088-485f-a499-6a1eaffd8d62)
---
**After change**
1. In step 3 like above, it should have an initial empty row. (as same when click "+Add" button)
![image](https://github.com/mate-n/tpms/assets/3841068/44c6d700-1fe3-4c3f-bee3-b98f253667df)
---
Demo video
https://github.com/mate-n/tpms/assets/3841068/9b706b29-a58c-447b-abef-828c0e2a2701



